### PR TITLE
Fix missing '[' from conditional in bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -165,7 +165,7 @@ fetchTool()
     xmlFileAsString=`cat "$vcpkgRootDir/scripts/vcpkgTools.xml"`
     toolRegexStart="<tool name=\"$tool\" os=\"$os\">"
     toolData="$(extractStringBetweenDelimiters "$xmlFileAsString" "$toolRegexStart" "</tool>")"
-    if [ "$toolData" = "" ] || [[ "$toolData" == "<?xml"* ]]; then
+    if [[ "$toolData" = "" ] || [[ "$toolData" == "<?xml"* ]]; then
         echo "No entry for $toolRegexStart in $vcpkgRootDir/scripts/vcpkgTools.xml"
         return 1
     fi


### PR DESCRIPTION
- #### What does your PR fix?  
  Fixes missing '[' from conditional in bootstrap.sh

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `have not - very minor change only `

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
 no, not updated

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
no